### PR TITLE
Set the properties of the NVMe inventory to the inventory manager as …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,31 @@ AC_ARG_VAR(LED_CONTROLLER_IFACE, [The LED controller interface])
 AS_IF([test "x$LED_CONTROLLER_IFACE" == "x"], [LED_CONTROLLER_IFACE="xyz.openbmc_project.Led.Physical"])
 AC_DEFINE_UNQUOTED([LED_CONTROLLER_IFACE], ["$LED_CONTROLLER_IFACE"], [The LED controller interface])
 
+# item interface
+AC_ARG_VAR(ITEM_IFACE, [The item interface])
+AS_IF([test "x$ITEM_IFACE" == "x"], [ITEM_IFACE="xyz.openbmc_project.Inventory.Item"])
+AC_DEFINE_UNQUOTED([ITEM_IFACE], ["$ITEM_IFACE"], [The item interface])
+
+# NVMe status interface
+AC_ARG_VAR(NVME_STATUS_IFACE, [The NVMe status interface])
+AS_IF([test "x$NVME_STATUS_IFACE" == "x"], [NVME_STATUS_IFACE="xyz.openbmc_project.Nvme.Status"])
+AC_DEFINE_UNQUOTED([NVME_STATUS_IFACE], ["$NVME_STATUS_IFACE"], [The NVMe status interface])
+
+# Asset interface
+AC_ARG_VAR(ASSET_IFACE, [The Asset interface])
+AS_IF([test "x$ASSET_IFACE" == "x"], [ASSET_IFACE="xyz.openbmc_project.Inventory.Decorator.Asset"])
+AC_DEFINE_UNQUOTED([ASSET_IFACE], ["$ASSET_IFACE"], [The Asset interface])
+
+# Inventory dbus busname
+AC_ARG_VAR(INVENTORY_BUSNAME, [The inventory busname])
+AS_IF([test "x$INVENTORY_BUSNAME" == "x"], [INVENTORY_BUSNAME="xyz.openbmc_project.Inventory.Manager"])
+AC_DEFINE_UNQUOTED([INVENTORY_BUSNAME], ["$INVENTORY_BUSNAME"], [The inventory busname])
+
+# Inventory path
+AC_ARG_VAR(INVENTORY_PATH, [The inventory path])
+AS_IF([test "x$INVENTORY_PATH" == "x"], [INVENTORY_PATH="/xyz/openbmc_project/inventory/system/chassis/motherboard/nvme"])
+AC_DEFINE_UNQUOTED([INVENTORY_PATH], ["$INVENTORY_PATH"], [The inventory path])
+
 LT_INIT # Required for systemd linking
 
 # Create configured output

--- a/nvme_manager.hpp
+++ b/nvme_manager.hpp
@@ -78,6 +78,12 @@ class Nvme
 
     bool getLEDGroupState(std::string &ledPath);
 
+    template <typename T>
+    void setInventoryParm(std::string &objPath, const std::string &interface, const std::string &property, const T &value);
+
+    void setNvmeInventoryProperties(bool present, phosphor::nvme::Nvme::NVMeData nvmeData, std::string inventoryPath);
+    void assertFaultLog(int smartWarning, std::string inventoryPath);
+
   private:
     sdbusplus::bus::bus &bus;
 

--- a/nvmes.cpp
+++ b/nvmes.cpp
@@ -13,43 +13,6 @@ namespace nvme
 using namespace std;
 using namespace phosphor::logging;
 
-void NvmeSSD::assertFaultLog(int smartWarning)
-{
-    std::vector<bool> bits;
-
-    for (int i = 0; i < 5; i++)
-    {
-        if (((smartWarning >> i) & 1) == 0)
-            bits.push_back(true);
-        else
-            bits.push_back(false);
-
-        switch (i)
-        {
-            case 0:
-                InfoIface::capacityFault(bits[i]);
-                break;
-            case 1:
-                InfoIface::temperatureFault(bits[i]);
-                break;
-            case 2:
-                InfoIface::degradesFault(bits[i]);
-                break;
-            case 3:
-                InfoIface::mediaFault(bits[i]);
-                break;
-            case 4:
-                InfoIface::backupDeviceFault(bits[i]);
-                break;
-        }
-    }
-}
-
-void NvmeSSD::setPresent(const bool value)
-{
-    ItemIface::present(value);
-}
-
 void NvmeSSD::checkSensorThreshold()
 {
     uint64_t value = ValueIface::value();
@@ -77,20 +40,9 @@ void NvmeSSD::setSensorThreshold(uint64_t criticalHigh, uint64_t criticalLow,
     ValueIface::minValue(minValue);
 }
 
-void NvmeSSD::setPropertiesToDbus(const u_int64_t value,
-                                  const std::string vendorID,
-                                  const std::string serialNumber,
-                                  const std::string smartWarnings,
-                                  const std::string statusFlags,
-                                  const std::string driveLifeUsed
-                                  )
+void NvmeSSD::setSensorValueToDbus(const u_int64_t value)
 {
     ValueIface::value(value);
-    AssetIface::manufacturer(vendorID);
-    AssetIface::serialNumber(serialNumber);
-    InfoIface::smartWarnings(smartWarnings);
-    InfoIface::statusFlags(statusFlags);
-    InfoIface::driveLifeUsed(driveLifeUsed);
 }
 
 } // namespace nvme

--- a/nvmes.hpp
+++ b/nvmes.hpp
@@ -17,8 +17,6 @@ namespace nvme
 {
 
 using ValueIface = sdbusplus::xyz::openbmc_project::Sensor::server::Value;
-using InfoIface = sdbusplus::xyz::openbmc_project::Nvme::server::Status;
-using ItemIface = sdbusplus::xyz::openbmc_project::Inventory::server::Item;
 
 using CriticalInterface =
     sdbusplus::xyz::openbmc_project::Sensor::Threshold::server::Critical;
@@ -26,12 +24,8 @@ using CriticalInterface =
 using WarningInterface =
     sdbusplus::xyz::openbmc_project::Sensor::Threshold::server::Warning;
 
-using AssetIface =
-    sdbusplus::xyz::openbmc_project::Inventory::Decorator::server::Asset;
-
 using NvmeIfaces =
-    sdbusplus::server::object::object<ValueIface, InfoIface, ItemIface,
-                                      AssetIface, CriticalInterface, WarningInterface>;
+    sdbusplus::server::object::object<ValueIface, CriticalInterface, WarningInterface>;
 
 class NvmeSSD : public NvmeIfaces
 {
@@ -48,15 +42,7 @@ class NvmeSSD : public NvmeIfaces
     {
     }
 
-    void setPresent(const bool value);
-
-    void assertFaultLog(int smartWarning);
-
-    void setPropertiesToDbus(const u_int64_t value, const std::string vendorID,
-                             const std::string serialNumber,
-                             const std::string smartWarnings,
-                             const std::string statusFlags,
-                             const std::string driveLifeUsed);
+    void setSensorValueToDbus(const u_int64_t value);
     void checkSensorThreshold();
     void setSensorThreshold(uint64_t criticalHigh, uint64_t criticalLow,
                             uint64_t maxValue, uint64_t minValue);


### PR DESCRIPTION
…described in proposal

- Moving interfaces xyz.openbmc_project.Inventory.Decorator.Asset,
xyz.openbmc_project.Inventory.Item, xyz.openbmc_project.Nvme.Status
to path /xyz/openbmc_project/inventory/system/chassis/motherboard/nvme0-7

- Set those properties to the appropriate interfaces and then clear the values
 instead of erasing the objects if needed.